### PR TITLE
Add --correct-static-generator-methods flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,7 @@ decaffeinate could be improved, feel free to file an issue on the [issues] page.
   before `super` or omit the `super` call in a subclass.
 * `--bind-methods-after-super-call`: Bind methods after `super` constructor call to avoid
   the invalid constructor error (see `--disallow-invalid-constructors`)
+* `--correct-static-generator-methods`: provides a correct syntax on converting a static generator method.
 
 For more usage details, see the output of `decaffeinate --help`.
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -99,6 +99,10 @@ function parseArguments(args: Array<string>): CLIOptions {
         baseOptions.bindMethodsAfterSuperCall = true;
         break;
 
+      case '--correct-static-generator-methods':
+        baseOptions.correctStaticGeneratorMethods = true;
+        break;
+
       case '--loose':
         baseOptions.looseDefaultParams = true;
         baseOptions.looseForExpressions = true;

--- a/src/options.ts
+++ b/src/options.ts
@@ -18,6 +18,7 @@ export type Options = {
   disableBabelConstructorWorkaround?: boolean,
   disallowInvalidConstructors?: boolean,
   bindMethodsAfterSuperCall?: boolean,
+  correctStaticGeneratorMethods?: boolean,
 };
 
 export const DEFAULT_OPTIONS: Options = {
@@ -40,4 +41,5 @@ export const DEFAULT_OPTIONS: Options = {
   disableBabelConstructorWorkaround: false,
   disallowInvalidConstructors: false,
   bindMethodsAfterSuperCall: false,
+  correctStaticGeneratorMethods: false,
 };

--- a/src/stages/main/patchers/ClassAssignOpPatcher.ts
+++ b/src/stages/main/patchers/ClassAssignOpPatcher.ts
@@ -43,7 +43,16 @@ export default class ClassAssignOpPatcher extends ObjectBodyMemberPatcher {
       } else {
         throw this.error('Unexpected static method key type.');
       }
-      this.overwrite(this.key.outerStart, replaceEnd, 'static ');
+
+      let replaceStart = this.key.outerStart;
+      let replacement = 'static ';
+
+      if(this.isGeneratorMethod() && this.shouldCorrectStaticGeneratorMethod()) {
+        replacement = replacement + '*';
+        replaceStart = replaceStart - 1;
+      }
+
+      this.overwrite(replaceStart, replaceEnd, replacement);
     }
   }
 
@@ -168,5 +177,9 @@ export default class ClassAssignOpPatcher extends ObjectBodyMemberPatcher {
   isMethod(): boolean {
     return this.expression instanceof ManuallyBoundFunctionPatcher ||
       super.isMethod();
+  }
+
+  shouldCorrectStaticGeneratorMethod(): boolean {
+    return !!this.options.correctStaticGeneratorMethods;
   }
 }


### PR DESCRIPTION
Fix a bug on converting a static generator method.

It's the copy of https://github.com/si-lcmt/decaffeinate/pull/2, but this time into `master`.